### PR TITLE
add smart cabin telemetry

### DIFF
--- a/main.js
+++ b/main.js
@@ -101,7 +101,8 @@ define([
     './platform/entanglement/bundle',
     './platform/search/bundle',
     './platform/status/bundle',
-    './platform/commonUI/regions/bundle'
+    './platform/commonUI/regions/bundle',
+    './smart-cabin/telemetry/bundle',
 ], function (Main, legacyRegistry) {
     return {
         legacyRegistry: legacyRegistry,

--- a/smart-cabin/telemetry/bundle.js
+++ b/smart-cabin/telemetry/bundle.js
@@ -1,0 +1,90 @@
+define([
+    'legacyRegistry',
+    './src/CabinTelemetryServerAdapter',
+    './src/CabinTelemetryInitializer',
+    './src/CabinTelemetryModelProvider'
+], function (
+    legacyRegistry,
+    CabinTelemetryServerAdapter,
+    CabinTelemetryInitializer,
+    CabinTelemetryModelProvider
+) {
+    legacyRegistry.register("smart-cabin/telemetry", {
+        "name": "Smart Cabin Telemetry Adapter",
+        "extensions": {
+            "types": [
+                {
+                    "name": "Smart Cabin",
+                    "key": "example.cabin",
+                    "glyph": "o"
+                },
+                {
+                    "name": "Subsystem",
+                    "key": "example.subsystem",
+                    "glyph": "o",
+                    "model": { "composition": [] }
+                },
+                {
+                    "name": "Measurement",
+                    "key": "example.measurement",
+                    "glyph": "T",
+                    "model": { "telemetry": {} },
+                    "telemetry": {
+                        "source": "example.source",
+                        "domains": [
+                            {
+                                "name": "Time",
+                                "key": "timestamp"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "roots": [
+                {
+                    "id": "example:sc",
+                    "priority": "preferred",
+                    "model": {
+                        "type": "example.cabin",
+                        "name": "Smart Cabin",
+                        "composition": []
+                    }
+                }
+            ],
+            "services": [
+                {
+                    "key": "example.adapter",
+                    "implementation": CabinTelemetryServerAdapter,
+                    "depends": [ "$q", "CABIN_WS_URL" ]
+                }
+            ],
+            "constants": [
+                {
+                    "key": "CABIN_WS_URL",
+                    "priority": "fallback",
+                    "value": "ws://localhost:8081"
+                }
+            ],
+            "runs": [
+                {
+                    "implementation": CabinTelemetryInitializer,
+                    "depends": [ "example.adapter", "objectService" ]
+                }
+            ],
+            "components": [
+                {
+                    "provides": "modelService",
+                    "type": "provider",
+                    "implementation": CabinTelemetryModelProvider,
+                    "depends": [ "example.adapter", "$q" ]
+                },
+                {
+                    "provides": "telemetryService",
+                    "type": "provider",
+                    "implementation": "CabinTelemetryProvider.js",
+                    "depends": [ "example.adapter", "$q" ]
+                }
+            ]
+        }
+    });
+});

--- a/smart-cabin/telemetry/src/CabinTelemetryInitializer.js
+++ b/smart-cabin/telemetry/src/CabinTelemetryInitializer.js
@@ -1,0 +1,49 @@
+/*global define*/
+
+define(
+    function () {
+        "use strict";
+
+        var TAXONOMY_ID = "example:sc",
+            PREFIX = "example_tlm:";
+
+        function CabinTelemetryInitializer(adapter, objectService) {
+            // Generate a domain object identifier for a dictionary element
+            function makeId(element) {
+                return PREFIX + element.identifier;
+            }
+
+            // When the dictionary is available, add all subsystems
+            // to the composition of My Spacecraft
+            function initializeTaxonomy(dictionary) {
+                // Get the top-level container for dictionary objects
+                // from a group of domain objects.
+                function getTaxonomyObject(domainObjects) {
+                    return domainObjects[TAXONOMY_ID];
+                }
+
+                // Populate
+                function populateModel(taxonomyObject) {
+                    return taxonomyObject.useCapability(
+                        "mutation",
+                        function (model) {
+                            model.name =
+                                dictionary.name;
+                            model.composition =
+                                dictionary.subsystems.map(makeId);
+                        }
+                    );
+                }
+
+                // Look up My Spacecraft, and populate it accordingly.
+                objectService.getObjects([TAXONOMY_ID])
+                    .then(getTaxonomyObject)
+                    .then(populateModel);
+            }
+
+            adapter.dictionary().then(initializeTaxonomy);
+        }
+
+        return CabinTelemetryInitializer;
+    }
+);

--- a/smart-cabin/telemetry/src/CabinTelemetryModelProvider.js
+++ b/smart-cabin/telemetry/src/CabinTelemetryModelProvider.js
@@ -1,0 +1,80 @@
+/*global define*/
+
+define(
+    function () {
+        "use strict";
+
+        var PREFIX = "example_tlm:",
+            FORMAT_MAPPINGS = {
+                float: "number",
+                integer: "number",
+                string: "string"
+            };
+
+        function CabinTelemetryModelProvider(adapter, $q) {
+            var modelPromise, empty = $q.when({});
+
+            // Check if this model is in our dictionary (by prefix)
+            function isRelevant(id) {
+                return id.indexOf(PREFIX) === 0;
+            }
+
+            // Build a domain object identifier by adding a prefix
+            function makeId(element) {
+                return PREFIX + element.identifier;
+            }
+
+            // Create domain object models from this dictionary
+            function buildTaxonomy(dictionary) {
+                var models = {};
+
+                // Create & store a domain object model for a measurement
+                function addMeasurement(measurement) {
+                    var format = FORMAT_MAPPINGS[measurement.type];
+                    models[makeId(measurement)] = {
+                        type: "example.measurement",
+                        name: measurement.name,
+                        telemetry: {
+                            key: measurement.identifier,
+                            ranges: [{
+                                key: "value",
+                                name: "Value",
+                                units: measurement.units,
+                                format: format
+                            }]
+                        }
+                    };
+                }
+
+                // Create & store a domain object model for a subsystem
+                function addSubsystem(subsystem) {
+                    var measurements =
+                        (subsystem.measurements || []);
+                    models[makeId(subsystem)] = {
+                        type: "example.subsystem",
+                        name: subsystem.name,
+                        composition: measurements.map(makeId)
+                    };
+                    measurements.forEach(addMeasurement);
+                }
+
+                (dictionary.subsystems || []).forEach(addSubsystem);
+
+                return models;
+            }
+
+            // Begin generating models once the dictionary is available
+            modelPromise = adapter.dictionary().then(buildTaxonomy);
+
+            return {
+                getModels: function (ids) {
+                    // Return models for the dictionary only when they
+                    // are relevant to the request.
+                    return ids.some(isRelevant) ? modelPromise : empty;
+                }
+            };
+        }
+
+        return CabinTelemetryModelProvider;
+    }
+);

--- a/smart-cabin/telemetry/src/CabinTelemetryProvider.js
+++ b/smart-cabin/telemetry/src/CabinTelemetryProvider.js
@@ -1,0 +1,82 @@
+/*global define*/
+
+define(
+    ['./CabinTelemetrySeries'],
+    function (CabinTelemetrySeries) {
+        "use strict";
+
+        var SOURCE = "example.source";
+
+        function CabinTelemetryProvider(adapter, $q) {
+            var subscribers = {};
+
+            // Used to filter out requests for telemetry
+            // from some other source
+            function matchesSource(request) {
+                return (request.source === SOURCE);
+            }
+
+            // Listen for data, notify subscribers
+            adapter.listen(function (message) {
+                var packaged = {};
+                packaged[SOURCE] = {};
+                packaged[SOURCE][message.id] =
+                    new CabinTelemetrySeries([message.value]);
+                (subscribers[message.id] || []).forEach(function (cb) {
+                    cb(packaged);
+                });
+            });
+
+            return {
+                requestTelemetry: function (requests) {
+                    var packaged = {},
+                        relevantReqs = requests.filter(matchesSource);
+
+                    // Package historical telemetry that has been received
+                    function addToPackage(history) {
+                        packaged[SOURCE][history.id] =
+                            new CabinTelemetrySeries(history.value);
+                    }
+
+                    // Retrieve telemetry for a specific measurement
+                    function handleRequest(request) {
+                        var key = request.key;
+                        return adapter.history(key).then(addToPackage);
+                    }
+
+                    packaged[SOURCE] = {};
+                    return $q.all(relevantReqs.map(handleRequest))
+                        .then(function () { return packaged; });
+                },
+                subscribe: function (callback, requests) {
+                    var keys = requests.filter(matchesSource)
+                       .map(function (req) { return req.key; });
+
+                   function notCallback(cb) {
+                       return cb !== callback;
+                   }
+
+                   function unsubscribe(key) {
+                       subscribers[key] =
+                           (subscribers[key] || []).filter(notCallback);
+                       if (subscribers[key].length < 1) {
+                           adapter.unsubscribe(key);
+                       }
+                   }
+
+                   keys.forEach(function (key) {
+                       subscribers[key] = subscribers[key] || [];
+                       adapter.subscribe(key);
+                       subscribers[key].push(callback);
+                   });
+
+                   return function () {
+                       keys.forEach(unsubscribe);
+                   };
+                }
+            };
+        }
+
+        return CabinTelemetryProvider;
+    }
+);

--- a/smart-cabin/telemetry/src/CabinTelemetrySeries.js
+++ b/smart-cabin/telemetry/src/CabinTelemetrySeries.js
@@ -1,0 +1,23 @@
+/*global define*/
+
+define(
+    function () {
+        "use strict";
+
+        function CabinTelemetrySeries(data) {
+            return {
+                getPointCount: function () {
+                    return data.length;
+                },
+                getDomainValue: function (index) {
+                    return (data[index] || {}).timestamp;
+                },
+                getRangeValue: function (index) {
+                    return (data[index] || {}).value;
+                }
+            };
+        }
+
+        return CabinTelemetrySeries;
+    }
+);

--- a/smart-cabin/telemetry/src/CabinTelemetryServerAdapter.js
+++ b/smart-cabin/telemetry/src/CabinTelemetryServerAdapter.js
@@ -1,0 +1,62 @@
+/*global define,WebSocket*/
+
+define(
+    [],
+    function () {
+        "use strict";
+
+        function CabinTelemetryServerAdapter($q, wsUrl) {
+            var ws = new WebSocket(wsUrl),
+                histories = {},
+                listeners = [],
+                dictionary = $q.defer();
+
+            // Handle an incoming message from the server
+            ws.onmessage = function (event) {
+                var message = JSON.parse(event.data);
+
+                switch (message.type) {
+                    case "dictionary":
+                        dictionary.resolve(message.value);
+                        break;
+                    case "history":
+                        histories[message.id].resolve(message);
+                        delete histories[message.id];
+                        break;
+                    case "data":
+                        listeners.forEach(function (listener) {
+                            listener(message);
+                        });
+                        break;
+                }
+            };
+
+            // Request dictionary once connection is established
+            ws.onopen = function () {
+                ws.send("dictionary");
+            };
+
+            return {
+                dictionary: function () {
+                    return dictionary.promise;
+                },
+                history: function (id) {
+                    histories[id] = histories[id] || $q.defer();
+                    ws.send("history " + id);
+                    return histories[id].promise;
+                },
+                subscribe: function (id) {
+                    ws.send("subscribe " + id);
+                },
+                unsubscribe: function (id) {
+                    ws.send("unsubscribe " + id);
+                },
+                listen: function (callback) {
+                    listeners.push(callback);
+                }
+            };
+        }
+
+        return CabinTelemetryServerAdapter;
+    }
+);


### PR DESCRIPTION
Added adapters/listeners for the sensors telemetry mockup.

Run [Sensors Data Mockup Server](https://github.com/Proekspert/sensordata-server) to display telemetry on the dashboard.